### PR TITLE
Editing creation_metadata and anonymize_fields methods in  utilities.py.

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -49,7 +49,7 @@ def creation_metadata(data,primary_key):
     #Check if primary_key is of e.g. SYNTETHIC12
     config = parse_config("./config.yaml")
     model_name = config["models"]["active"]
-    #Retrieve the Regex of the primary key
+    #Retrieve the Regex of  primary key
     regex    = config["models"][model_name]["regex_primary_key"]
     
     for el in list(data[primary_key]):


### PR DESCRIPTION
We added several checks in two methods.
In creation_metadata method we check:
- if Data Set is not empty, otherwise it throws an exception "Empty Data Set";
- if the passed primary_key is present as Feature, otherwise it throws an exception "Primary Key is not present as Feature";
-  if the passed primary_key values  satisfied the given regex, otherwise it throws an exception "Wrong Primary Key Formatting";

In anonymize_fields method we check:
- if name_of_the_fields or   category_of_the_fields are  None, otherwise raise an exception "Passing None argument";
- if the arguments are array type, otherwise it throws an Exception("No Type List/Array");
- if name_of_the_fields and category_of_the_fields have the same size, otherwise it throws an exception "Length of name_of_the_fields different from Length of category_of_the_fields".